### PR TITLE
PowerShell deployment improvements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,54 @@
+# Based on DNX gitattributes
+*.doc  diff=astextplain
+*.DOC	diff=astextplain
+*.docx	diff=astextplain
+*.DOCX	diff=astextplain
+*.dot	diff=astextplain
+*.DOT	diff=astextplain
+*.pdf	diff=astextplain
+*.PDF	diff=astextplain
+*.rtf	diff=astextplain
+*.RTF	diff=astextplain
+
+*.jpg  	binary
+*.png 	binary
+*.gif 	binary
+
+*.cs text=auto diff=csharp 
+*.vb text=auto
+*.resx text=auto
+*.c text=auto
+*.cpp text=auto
+*.cxx text=auto
+*.h text=auto
+*.hxx text=auto
+*.py text=auto
+*.rb text=auto
+*.java text=auto
+*.html text=auto
+*.htm text=auto
+*.css text=auto
+*.scss text=auto
+*.sass text=auto
+*.less text=auto
+*.js text=auto
+*.lisp text=auto
+*.clj text=auto
+*.sql text=auto
+*.php text=auto
+*.lua text=auto
+*.m text=auto
+*.asm text=auto
+*.erl text=auto
+*.fs text=auto
+*.fsx text=auto
+*.hs text=auto
+
+*.csproj text=auto
+*.vbproj text=auto
+*.fsproj text=auto
+*.dbproj text=auto
+*.sln text=auto eol=crlf
+
+# .sh files need to have Linux style line endings to run as part of Azure VM extension
+*.sh text eol=lf

--- a/deploy/Install-MRP-app.sh
+++ b/deploy/Install-MRP-app.sh
@@ -1,17 +1,22 @@
 #!/bin/bash
 
 # Auto-accept license for Java
-echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
+echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | sudo /usr/bin/debconf-set-selections
 
 # Install packages
-add-apt-repository ppa:webupd8team/java
+add-apt-repository ppa:webupd8team/java -y
 apt-get update
 apt-get install oracle-java8-installer -y
 apt-get install mongodb -y
 apt-get install tomcat7 -y
 apt-get install wget -y
 
+# Set Java environment variables
 export JAVA_HOME=/usr/lib/jvm/java-8-oracle
+export PATH=$PATH:/usr/lib/jvm/java-8-oracle/bin
+
+# Create symlink to Java for Tomcat
+sudo ln -s /usr/lib/jvm/java-8-oracle /usr/lib/jvm/default-java
 
 # Configure the storage account and container name here
 DropStorageAccountName=""

--- a/deploy/Install-MRP-app.sh
+++ b/deploy/Install-MRP-app.sh
@@ -1,45 +1,28 @@
-﻿#!/bin/bash
+#!/bin/bash
+
+# Auto-accept license for Java
+echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
 
 # Install packages
+add-apt-repository ppa:webupd8team/java
 apt-get update
-apt-get install openjdk-8-jdk -y
-apt-get install openjdk-8-jre -y
+apt-get install oracle-java8-installer -y
 apt-get install mongodb -y
-apt-get install tomcat7 -y
 apt-get install wget -y
-
-# Set Java environment variables
-export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-export PATH=$PATH:/usr/lib/jvm/java-8-openjdk-amd64/bin
 
 # Configure the storage account and container name here
 DropStorageAccountName=""
-DropContainerName=""
+DropContainerName="mrp-drops"
 AzureResource="https://$DropStorageAccountName.blob.core.windows.net/$DropContainerName/"
 
-# Download MongoRecords.js from Azure blog storage
+# Download MongoRecords.js from Azure blob storage
 wget ${AzureResource}MongoRecords.js
 
 # Wait for 10 seconds to make sure previous step is completed
 sleep 10
 
 # Add the records to ordering database on MongoDB
-mongo ordering MongoRecords.js
-
-# Change Tomcat listening port from 8080 to 9080
-sed -i s/8080/9080/g /etc/tomcat7/server.xml
-
-# Download the client WAR file
-wget ${AzureResource}mrp.war
-
-# Wait for 10 seconds to make sure previous step is completed
-sleep 10
-
-# Copy WAR file to Tomcat directory for auto-deployment
-cp mrp.war /var/lib/tomcat7/webapps
-
-# Restart Tomcat
-/etc/init.d/tomcat7 restart
+mongo --nodb MongoRecords.js
 
 # Download the Ordering Service jar from Azure storage
 wget ${AzureResource}ordering-service-0.1.0.jar
@@ -50,4 +33,4 @@ sleep 20
 # Run Ordering Service app
 java -jar ordering-service-0.1.0.jar &
 
-echo "MRP application successfully deployed. Go to http://$HOSTNAME.cloudapp.net:9080/mrp"
+echo "MRP application successfully deployed"

--- a/deploy/Install-MRP-app.sh
+++ b/deploy/Install-MRP-app.sh
@@ -11,6 +11,8 @@ apt-get install mongodb -y
 apt-get install tomcat7 -y
 apt-get install wget -y
 
+export JAVA_HOME=/usr/lib/jvm/java-8-oracle
+
 # Configure the storage account and container name here
 DropStorageAccountName=""
 DropContainerName="mrp-drops"

--- a/deploy/Install-MRP-app.sh
+++ b/deploy/Install-MRP-app.sh
@@ -8,6 +8,7 @@ add-apt-repository ppa:webupd8team/java
 apt-get update
 apt-get install oracle-java8-installer -y
 apt-get install mongodb -y
+apt-get install tomcat7 -y
 apt-get install wget -y
 
 # Configure the storage account and container name here
@@ -23,6 +24,21 @@ sleep 10
 
 # Add the records to ordering database on MongoDB
 mongo --nodb MongoRecords.js
+
+# Change Tomcat listening port from 8080 to 9080
+sed -i s/8080/9080/g /etc/tomcat7/server.xml
+
+# Download the client WAR file
+wget ${AzureResource}mrp.war
+
+# Wait for 10 seconds to make sure previous step is completed
+sleep 10
+
+# Copy WAR file to Tomcat directory for auto-deployment
+cp mrp.war /var/lib/tomcat7/webapps
+
+# Restart Tomcat
+/etc/init.d/tomcat7 restart
 
 # Download the Ordering Service jar from Azure storage
 wget ${AzureResource}ordering-service-0.1.0.jar

--- a/deploy/MongoRecords.js
+++ b/deploy/MongoRecords.js
@@ -1,3 +1,19 @@
+var conn;
+while (conn === undefined)
+{
+    try
+    {
+        conn = new Mongo("localhost:27017");
+    }
+    catch (e)
+    {
+        print(e);
+    }
+
+    sleep(100);
+}
+
+db = conn.getDB("ordering");
 db.catalog.insert(
 [
   {"skuNumber" : "LIG-0001", "description" : "Helogen Headlights (2 Pack)", "price" : 38.99, "inventory" : 10, "leadTime" : 3},

--- a/deploy/PowerShell/ProvisionAzureLinuxVM.ps1
+++ b/deploy/PowerShell/ProvisionAzureLinuxVM.ps1
@@ -81,6 +81,7 @@ $script = [IO.File]::ReadAllText("$ScriptPath\..\$AppInstallScript") -replace 'D
 Set-AzureStorageBlobContent -Blob $AppInstallScript -Container $DropContainerName -File "$ScriptPath\..\$AppInstallScript" -Force
 Set-AzureStorageBlobContent -Blob "MongoRecords.js" -Container $DropContainerName -File "$ScriptPath\..\MongoRecords.js" -Force
 Set-AzureStorageBlobContent -Blob "ordering-service-0.1.0.jar" -Container $DropContainerName -File "$ScriptPath\..\..\builds\ordering-service-0.1.0.jar" -Force
+Set-AzureStorageBlobContent -Blob "mrp.war" -Container $DropContainerName -File "$ScriptPath\..\..\builds\mrp.war" -Force
 #----------------------------------------------------
 
 #----------------------------------------------------

--- a/deploy/PowerShell/ProvisionAzureLinuxVM.ps1
+++ b/deploy/PowerShell/ProvisionAzureLinuxVM.ps1
@@ -1,14 +1,16 @@
-﻿#----------------------------------------------------
+﻿Switch-AzureMode -Name AzureServiceManagement
+
+#----------------------------------------------------
 # Current Command Path Location
 #----------------------------------------------------
-[string]$ScriptPath = Split-Path -Path $MyInvocation.MyCommand.Path;
+[string]$ScriptPath = Split-Path -Path $MyInvocation.MyCommand.Path
 
 #----------------------------------------------------
 # MRP Application Binaries and Deployment Script Location
 #----------------------------------------------------
-[string]$DropStorageAccountName = "<<CONFIGURE>>"
-[string]$DropContainerName = "drops"
-[string]$AppInstallScript = "Install-MRP.sh"
+[string]$StorageAccountName = "<<CONFIGURE>>"
+[string]$DropContainerName = "mrp-drops"
+[string]$AppInstallScript = "Install-MRP-app.sh"
 #----------------------------------------------------
 
 #----------------------------------------------------
@@ -16,11 +18,10 @@
 #----------------------------------------------------
 [string]$SubscriptionName = "<<CONFIGURE>>"
 [string]$AzureLocation = "West US"
-[string]$StorageAccountName = "<<CONFIGURE>>"
-[string]$ContainerName = "vm-vhds"
+[string]$VhdsContainerName = "mrp-vhds"
 [string]$CloudSvcName = "<<CONFIGURE>>"
 [string]$NetworkConfigFile = "AzureNetworks.netcfg"
-[string]$VirtualNetwork = "<<CONFIGURE>>"
+[string]$VirtualNetwork = "mrp-linux-vnet"
 [string]$VSubNet = "BackEndSubnet"
 [string]$LocalAdmin = "mrp_admin"
 [string]$LocalPass = "P2ssw0rd"
@@ -29,51 +30,64 @@
 #----------------------------------------------------
 
 #----------------------------------------------------
-#Copy Deployment files to Azure Blob Storage
-#----------------------------------------------------
-<#
-Set-AzureStorageBlobContent -Blob "ExecuteAppInstall.sh" -Container "$Global:DropContainerName" -File "$Global:ScriptPath\AppDeploy\ExecuteAppInstall.sh" -Force
-Set-AzureStorageBlobContent -Blob "InstallApp.sh" -Container "$Global:DropContainerName" -File "$Global:ScriptPath\AppDeploy\InstallApp.sh" -Force
-Set-AzureStorageBlobContent -Blob "MongoRecords.js" -Container "$Global:DropContainerName" -File "$Global:ScriptPath\AppDeploy\MongoRecords.js" -Force
-Set-AzureStorageBlobContent -Blob "ordering-service-0.1.0.jar" -Container "$Global:DropContainerName" -File "$Global:ScriptPath\AppDeploy\ordering-service-0.1.0.jar" -Force
-#>
-#----------------------------------------------------
-
-
-#----------------------------------------------------
 # Get Azure Subscription
 #----------------------------------------------------
 Write-Output "Connect to Azure Subscription"
-Get-AzurePublishSettingsFile
-$azurePublishSettingsFileLocation = Read-Host "Enter Azure Publish Settings File Path"
-Import-AzurePublishSettingsFile -PublishSettingsFile $azurePublishSettingsFileLocation
-Select-AzureSubscription -SubscriptionName $Global:SubscriptionName
-Set-AzureSubscription -SubscriptionName $Global:SubscriptionName
-Write-Output "Azure Subscription $Global:SubscriptionName is now the default PowerShell Azure subscription"
+$sub = Get-AzureSubscription -Name $SubscriptionName
+if ($sub -eq $null) {
+    Get-AzurePublishSettingsFile
+    $azurePublishSettingsFileLocation = Read-Host "Enter Azure Publish Settings File Path"
+    Import-AzurePublishSettingsFile -PublishSettingsFile $azurePublishSettingsFileLocation
+}
+
+Select-AzureSubscription -SubscriptionName $SubscriptionName
+Write-Output "Azure Subscription $SubscriptionName is now the default PowerShell Azure subscription"
 #-----------------------------------------------------
 
 #----------------------------------------------------
-# Create Azure Storage Account
+# Create Azure Storage Account (if missing)
 #----------------------------------------------------
-New-AzureStorageAccount -StorageAccountName "$Global:StorageAccountName" -Location "$Global:AzureLocation" -Type "Standard_LRS" -Description "Azure MRP Linux VM Storage Account" -Verbose;
-Write-Output -Verbose "Storage account '$Global:StorageAccountNamecreated' `n"
-Set-AzureSubscription -SubscriptionName "$Global:SubscriptionName" -CurrentStorageAccount "$Global:StorageAccountName" -Verbose
-Write-Output "$Global:StorageAccountName now set as the current storage account for the subscription $Global:SubscriptionName `n"
+$storage = Get-AzureStorageAccount -StorageAccountName $StorageAccountName -ErrorAction Ignore
+if ($storage -eq $null) {
+    New-AzureStorageAccount -StorageAccountName $StorageAccountName -Location $AzureLocation -Type "Standard_LRS" -Description "Azure MRP Storage Account" -Verbose
+    Write-Output -Verbose "Storage account '$StorageAccountName' created"
+}
+
+Set-AzureSubscription -SubscriptionName $SubscriptionName -CurrentStorageAccount $StorageAccountName -Verbose
+Write-Output "$StorageAccountName now set as the current storage account for the subscription $SubscriptionName"
 #----------------------------------------------------
 
 #----------------------------------------------------
 # Create Azure Storage Account Blob Container for VM VHDs
 #----------------------------------------------------
-New-AzureStorageContainer -Name $Global:ContainerName -Permission Off -Verbose
-Write-Output -Verbose "Storage container $Global:ContainerName created `n"
+$container = Get-AzureStorageContainer -Name $DropContainerName -ErrorAction Ignore
+if ($container -eq $null) {
+    New-AzureStorageContainer -Name $DropContainerName -Permission Blob -Verbose
+    Write-Output -Verbose "Storage container $DropContainerName created"
+}
+
+$container = Get-AzureStorageContainer -Name $VhdsContainerName -ErrorAction Ignore
+if ($container -eq $null) {
+    New-AzureStorageContainer -Name $VhdsContainerName -Permission Off -Verbose
+    Write-Output -Verbose "Storage container $VhdsContainerName created"
+}
 #----------------------------------------------------
 
+#----------------------------------------------------
+# Copy Deployment files to Azure Blob Storage
+#----------------------------------------------------
+$script = [IO.File]::ReadAllText("$ScriptPath\..\$AppInstallScript") -replace 'DropStorageAccountName=""', "DropStorageAccountName=`"$StorageAccountName`""
+[IO.File]::WriteAllText("$ScriptPath\..\$AppInstallScript", $script, (New-Object System.Text.UTF8Encoding $false))
+Set-AzureStorageBlobContent -Blob $AppInstallScript -Container $DropContainerName -File "$ScriptPath\..\$AppInstallScript" -Force
+Set-AzureStorageBlobContent -Blob "MongoRecords.js" -Container $DropContainerName -File "$ScriptPath\..\MongoRecords.js" -Force
+Set-AzureStorageBlobContent -Blob "ordering-service-0.1.0.jar" -Container $DropContainerName -File "$ScriptPath\..\..\builds\ordering-service-0.1.0.jar" -Force
+#----------------------------------------------------
 
 #----------------------------------------------------
-#Create Azure Virtual Network
+# Create Azure Virtual Network
 #----------------------------------------------------
-Set-AzureVNetConfig -ConfigurationPath "$Global:ScriptPath\$Global:NetworkConfigFile" -Verbose
-Write-Output -Verbose "Azure Virtual Network(s) have been created. `n"
+Set-AzureVNetConfig -ConfigurationPath "$ScriptPath\$NetworkConfigFile" -Verbose
+Write-Output -Verbose "Azure Virtual Network(s) have been created"
 #----------------------------------------------------
 
 #-----------------------------------------------------
@@ -85,17 +99,16 @@ $images = Get-AzureVMImage `
         | Sort-Object -Descending -Property PublishedDate
 $latestImage = $images[0].ImageName
 
-$ExtensionLocation = (Get-AzureStorageAccount -StorageAccountName "$Global:DropStorageAccountName").Endpoints[0] + "$Global:DropContainerName/$Global:AppInstallScript"
-$PublicConfiguration = '{"fileUris":["' + "$ExtensionLocation" + '"], "commandToExecute": "sh ' + $Global:AppInstallScript + '"}' 
+$ExtensionLocation = (Get-AzureStorageAccount -StorageAccountName $StorageAccountName).Endpoints[0] + "$DropContainerName/$AppInstallScript"
+$PublicConfiguration = '{"fileUris":["' + "$ExtensionLocation" + '"], "commandToExecute": "sh ' + $AppInstallScript + '"}' 
 
-$vm = New-AzureVMConfig -Name $Global:LinuxVM_Name -ImageName $latestImage -InstanceSize "Medium" -DiskLabel "$Global:LinuxVM_Name-OS"  -MediaLocation "https://$Global:StorageAccountName.blob.core.windows.net/$Global:ContainerName/$Global:LinuxVM_Name-OS_Disk.vhd"|
-        Add-AzureProvisioningConfig -Linux -LinuxUser "$Global:LocalAdmin" -Password "$Global:LocalPass" -Verbose |
+$vm = New-AzureVMConfig -Name $LinuxVM_Name -ImageName $latestImage -InstanceSize "Medium" -DiskLabel "$LinuxVM_Name-OS"  -MediaLocation "https://$StorageAccountName.blob.core.windows.net/$VhdsContainerName/$LinuxVM_Name-OS_Disk.vhd"|
+        Add-AzureProvisioningConfig -Linux -LinuxUser "$LocalAdmin" -Password "$LocalPass" -Verbose |
         Add-AzureEndpoint -Name "HTTP" -PublicPort 80 -LocalPort 8080 -Protocol "tcp" |
-        Add-AzureEndpoint -Name "HTTP2" -PublicPort 81 -LocalPort 8081 -Protocol "tcp" |
-        Set-AzureSubnet -SubnetNames "$Global:VSubNet" |
+        Set-AzureSubnet -SubnetNames "$VSubNet" |
         Set-AzureStaticVNetIP -IPAddress "$LinuxVM_IP" |
         Set-AzureVMExtension -ExtensionName "CustomScriptForLinux" -Publisher "Microsoft.OSTCExtensions" -Version "1.2" -PublicConfiguration $PublicConfiguration
-Add-AzureDataDisk -CreateNew -HostCaching "None" -DiskLabel "DataDisk-1" -DiskSizeInGB 500 -LUN "1" -MediaLocation "https://$Global:StorageAccountName.blob.core.windows.net/$Global:ContainerName/$Global:LinuxVM_Name-Data_Disk1.vhd" -VM $vm
-Add-AzureDataDisk -CreateNew -HostCaching "None" -DiskLabel "DataDisk-2" -DiskSizeInGB 500 -LUN "2" -MediaLocation "https://$Global:StorageAccountName.blob.core.windows.net/$Global:ContainerName/$Global:LinuxVM_Name-Data_Disk2.vhd" -VM $vm
-New-AzureVM -ServiceName "$Global:CloudSvcName" -Location "$Global:AzureLocation" -VNetName "$Global:VirtualNetwork" -VMs $vm -DeploymentName "$Global:LinuxVM_Name-Provision" -Verbose
+Add-AzureDataDisk -CreateNew -HostCaching "None" -DiskLabel "DataDisk-1" -DiskSizeInGB 500 -LUN "1" -MediaLocation "https://$StorageAccountName.blob.core.windows.net/$VhdsContainerName/$LinuxVM_Name-Data_Disk1.vhd" -VM $vm
+Add-AzureDataDisk -CreateNew -HostCaching "None" -DiskLabel "DataDisk-2" -DiskSizeInGB 500 -LUN "2" -MediaLocation "https://$StorageAccountName.blob.core.windows.net/$VhdsContainerName/$LinuxVM_Name-Data_Disk2.vhd" -VM $vm
+New-AzureVM -ServiceName "$CloudSvcName" -Location "$AzureLocation" -VNetName "$VirtualNetwork" -VMs $vm -DeploymentName "$LinuxVM_Name-Provision" -Verbose
 #-----------------------------------------------------

--- a/deploy/PowerShell/ProvisionAzureLinuxVM.ps1
+++ b/deploy/PowerShell/ProvisionAzureLinuxVM.ps1
@@ -96,7 +96,7 @@ Write-Output -Verbose "Azure Virtual Network(s) have been created"
 #-----------------------------------------------------
 Write-Output "Begin creation of Azure Linux VM"
 $images = Get-AzureVMImage `
-        | where { $_.ImageFamily -eq "Ubuntu Server 14.10" } `
+        | where { $_.ImageFamily -eq "Ubuntu Server 14.04 LTS" } `
         | Sort-Object -Descending -Property PublishedDate
 $latestImage = $images[0].ImageName
 


### PR DESCRIPTION
Bug fixes and improvements to streamline deployment via PowerShell:
* Add gitattributes file (based on DNX source) and include specific rule for *.sh files (need to use Unix-style line ending otherwise they don't run as expected).
* Switch to Oracle Java 8 as the Azure Storage client library throws exceptions when running on the OpenJDK.
* Remove the front-end from the deployment script (not up to date with the new MRP PartsUnlimited scenario).
* Add retry loop to MongoDB provisioning script. When run as part of a Azure PowerShell VM deployment script, sometimes it takes a bit of time after install before MongoDB starts responding to requests.
* Update PowerShell script to upload dependencies and reuse subscriptions / storage accounts.