### PR TITLE
Set the default of the mongodb host 

### DIFF
--- a/src/Backend/OrderService/src/test/resources/application.properties
+++ b/src/Backend/OrderService/src/test/resources/application.properties
@@ -20,7 +20,7 @@ ordering.pingMessage: Testing
 ordering.validationMessage: Testing
 
 # MongoDB server used for unit tests.
-mongodb.host: niklasg-ubuntu.cloudapp.net
+mongodb.host: localhost
 # Use a database separate from the production database.
 mongodb.database: orderingtest
 


### PR DESCRIPTION
Set the default of the mongodb host to localhost so that the unit tests run when executing the gradlew build command