### PR TITLE
Removing the replace command

### DIFF
--- a/deploy/SSH-MRP-Artifacts.ps1
+++ b/deploy/SSH-MRP-Artifacts.ps1
@@ -22,7 +22,6 @@ if (-not (Test-Path plink.exe)) {
 # Set deploy directory on target server
 $deployDirectory = "/tmp/mrpdeploy_" + [System.Guid]::NewGuid().toString()
 $buildName = $($env:BUILD_DEFINITIONNAME)
-$buildName = $buildName.Replace(".","")
 # Save sftp command text to file
 $sftpFile = "sftp.txt"
 $sftpContent = @'


### PR DESCRIPTION
We dont need it anymore, seems the PS1 task is updated now, work without it.

Context : In the past, if you used a "Dot" in the name of the build definition, the release was not able to take it, so we added a replace function in the ps1 script as a countermeasure.

Related to #81 #77 #76 #75 