### PR TITLE
update fixes for DCOS 1.8

### DIFF
--- a/docs/_posts/2016-10-20-adv-22-DCOS.md
+++ b/docs/_posts/2016-10-20-adv-22-DCOS.md
@@ -81,19 +81,22 @@ ACS is very simple to deploy, you can do it using Azure CLI but we will use the 
 
   > Note : If you have an error to open this two pages, you should fix it first before continue the next step. It may mean that your SSH tunnel connection is not working correctly
 
-2. Download on your local machine [the following marathon.json file](../assets/acs/env/marathon.json)
+2. Install the DCOS CLI, [more info here](https://docs.mesosphere.com/1.8/usage/cli/install/)  
+
+    - Use localhost for the url: `./dcos config set core.dcos_url http://localhost`  
+    - `dcos auth login` will not work and is unnecessary since the secure ssh tunnel has been established to the master node.
+
+3. Download on your local machine [the following marathon.json file](../assets/acs/env/marathon.json)
   >Note : This file contain the PartsUnlimitedMRP deployment
 
-3.  Edit this JSON file with your favorite editor by searching for : `"HAPROXY_0_VHOST":"YOURFQDN"` (lines 53 and 85) and replace `YOURFQDN` with the previous FQDN agents connection string that you copy in the previous section of this HOL
+4.  Edit this JSON file with your favorite editor by searching for : `"HAPROXY_0_VHOST":"YOURFQDN"` (lines 53 and 85) and replace `YOURFQDN` with the previous FQDN agents connection string that you copy in the previous section of this HOL
   > Note : In our example it will be `"HAPROXY_0_VHOST":"myacsjulienstrohagents.eastus.cloudapp.azure.com"`
 
-4. Save and close your marathon.json file with the new parameters
+5. Save and close your marathon.json file with the new parameters
 
-5. Open an other terminal, navigate to the folder where the marathon.json file is located, and enter the following command using the dcos CLI :
-  > Reminder : You must first install the DCOS CLI, [here more infos](https://docs.mesosphere.com/1.8/usage/cli/install/) !
+6. Open an other terminal, navigate to the folder where the marathon.json file is located, and enter the following command using the dcos CLI :
 
   ````bash
-  dcos auth login
   dcos package install marathon-lb
   ````
 
@@ -101,11 +104,11 @@ ACS is very simple to deploy, you can do it using Azure CLI but we will use the 
 
   ![](../assets/acs/marathonlb_install.png)
 
-6. Check on the marathon dashboard [(http://localhost/marathon)](http://localhost/marathon) if the deployment appear
+7. Check on the marathon dashboard [(http://localhost/marathon)](http://localhost/marathon) if the deployment appear
 
   ![](../assets/acs/acs_marathonlb_deployed.png)
 
-7. Back to your terminal, run the following command to deploy Parts Unlimited MRP on your cluster :
+8. Back to your terminal, run the following command to deploy Parts Unlimited MRP on your cluster :
 
   ````bash
   dcos marathon group add marathon.json
@@ -117,11 +120,11 @@ ACS is very simple to deploy, you can do it using Azure CLI but we will use the 
 
   ![](../assets/acs/pumrp_deploying.png)
 
-8. After few second the deployment should be on the **Running** state
+9. After few second the deployment should be on the **Running** state
 
   ![](../assets/acs/pumrp_running.png)
 
-9. You should be able to browse the application using the public agent FQDN of your cluster and see the result
+10. You should be able to browse the application using the public agent FQDN of your cluster and see the result
 
   > In my case I will browse my cluster using the current FQDN `http://myacsjulienstrohagents.eastus.cloudapp.azure.com/mrp`
   

--- a/docs/_posts/2016-10-20-adv-22-DCOS.md
+++ b/docs/_posts/2016-10-20-adv-22-DCOS.md
@@ -70,7 +70,7 @@ ACS is very simple to deploy, you can do it using Azure CLI but we will use the 
 
 1. The first step is to inniate the **SSH Tunnel Connection** on your cluster. There is multiple way to do it depends if you are on Mac/Linux or Windows, [you can read the multiple ways to do it by clicking here.](https://azure.microsoft.com/en-us/documentation/articles/container-service-connect/)
 
-  >Note : For example, using my previous example, here is my command : `sudo ssh Julien@myacsjulienstroh.eastus.cloudapp.azure.com -A -p 2200 -L 80:localhost:80 -i acs`
+  >Note : For example, using my previous example, here is my command : `sudo ssh -fNL 80:localhost:80 -p 2200 Julien@myacsjulienstroh.eastus.cloudapp.azure.com -i ~/.ssh/myACS_rsa`
 
 2. Navigate to the following web pages to verify if you connection works :
   * [DCOS Dashboard](http://localhost)

--- a/docs/_posts/2016-10-20-adv-22-DCOS.md
+++ b/docs/_posts/2016-10-20-adv-22-DCOS.md
@@ -15,7 +15,6 @@ We are recommanding you to read and do first the [HOL on Docker](https://microso
 
 ## Prerequisites ##
 
-* We will use the DCOS CLI, you should install it before, [read this procedure to do it](https://docs.mesosphere.com/1.7/usage/cli/install/)
 * If you are using Windows, we recomand to install the Bash on Windows feature, and do all the HOL commands using it
 
 > Note : All the screenshots and command are from a Mac environment, it could have some differences in terms of commands or procedure if you are using Windows. Read the feedbacks section at the end of this Labs to have more infos on how you can ask questions.
@@ -91,7 +90,7 @@ ACS is very simple to deploy, you can do it using Azure CLI but we will use the 
 4. Save and close your marathon.json file with the new parameters
 
 5. Open an other terminal, navigate to the folder where the marathon.json file is located, and enter the following command using the dcos CLI :
-  > Reminder : You must have the DCOS CLI installed, [here more infos](https://docs.mesosphere.com/1.7/usage/cli/install/) !
+  > Reminder : You must first install the DCOS CLI, [here more infos](https://docs.mesosphere.com/1.8/usage/cli/install/) !
 
   ````bash
   dcos auth login


### PR DESCRIPTION
- Move install from prerequisites to after cluster install and reference 1.8 install url
- Fix SSH tunnel sample command