### PR TITLE
Fixed PE version

### DIFF
--- a/docs/HOL_Deploying-Using-Puppet/README.md
+++ b/docs/HOL_Deploying-Using-Puppet/README.md
@@ -39,10 +39,10 @@ though _puppet programs_ on the Puppet Master.
     Simply click the Deploy to Azure button below and follow the wizard to deploy the two machines. You will need
     to log in to the Azure Portal.
                                                                      
-    <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FMicrosoft%2FPartsUnlimitedMRP%2Fmaster%2Fdocs%2FHOL_Deploying-Using-Puppet%2Fenv%2FPuppetPartsUnlimitedMRP.json" target="_blank">
+    <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fgzepeda%2FPartsUnlimitedMRP%2Fmaster%2Fdocs%2FHOL_Deploying-Using-Puppet%2Fenv%2FPuppetPartsUnlimitedMRP.json" target="_blank">
         <img src="http://azuredeploy.net/deploybutton.png"/>
     </a>
-    <a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FMicrosoft%2FPartsUnlimitedMRP%2Fmaster%2Fdocs%2FHOL_Deploying-Using-Puppet%2Fenv%2FPuppetPartsUnlimitedMRP.json" target="_blank">
+    <a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2Fgzepeda%2FPartsUnlimitedMRP%2Fmaster%2Fdocs%2FHOL_Deploying-Using-Puppet%2Fenv%2FPuppetPartsUnlimitedMRP.json" target="_blank">
         <img src="http://armviz.io/visualizebutton.png"/>
     </a>
 

--- a/docs/HOL_Deploying-Using-Puppet/env/PuppetPartsUnlimitedMRP.json
+++ b/docs/HOL_Deploying-Using-Puppet/env/PuppetPartsUnlimitedMRP.json
@@ -454,7 +454,7 @@
         "autoUpgradeMinorVersion": true,
         "settings": {
           "fileUris": [
-            "https://raw.githubusercontent.com/Microsoft/PartsUnlimitedMRP/master/docs/HOL_Deploying-Using-Puppet/env/install_puppetenterprise.sh"
+            "https://raw.githubusercontent.com/gzepeda/PartsUnlimitedMRP/master/docs/HOL_Deploying-Using-Puppet/env/install_puppetenterprise.sh"
           ]
         },
         "protectedSettings": {

--- a/docs/HOL_Deploying-Using-Puppet/env/PuppetPartsUnlimitedMRP.json
+++ b/docs/HOL_Deploying-Using-Puppet/env/PuppetPartsUnlimitedMRP.json
@@ -53,7 +53,7 @@
     "pmImagePublisher": "Canonical",
     "pmImageOffer": "UbuntuServer",
     "pmImageSku": "12.04.4-LTS",
-    "pmVersion": "2016.2.0",
+    "pmVersion": "2016.4.3",
     "mrpImagePublisher": "Canonical",
     "mrpImageOffer": "UbuntuServer",
     "mrpImageSku": "12.04.4-LTS",

--- a/docs/HOL_Deploying-Using-Puppet/env/install_puppetenterprise.sh
+++ b/docs/HOL_Deploying-Using-Puppet/env/install_puppetenterprise.sh
@@ -16,7 +16,7 @@ case $pe_version in
         pe_url=https://pm.puppetlabs.com/puppet-enterprise/2016.2.0/puppet-enterprise-2016.2.0-ubuntu-12.04-amd64.tar.gz
         ;;
     *)
-        pe_url=https://pm.puppetlabs.com/puppet-enterprise/2016.2.0/puppet-enterprise-2016.2.0-ubuntu-12.04-amd64.tar.gz
+        pe_url=https://pm.puppetlabs.com/puppet-enterprise/2016.4.3/puppet-enterprise-2016.4.3-ubuntu-12.04-amd64.tar.gz
         ;;
 esac
 


### PR DESCRIPTION
I changed the PE version in the ARM template and in the script that runs on Ubuntu so the installation of puppet completes. If it is left like this, the version 2016.2.0 is too old and the installation fails. 

This is a workaround until the scripts are updated to the latest version of Puppet Enterprise. 