### PR TITLE
updated customScript fileUris to match current location

### DIFF
--- a/Labfiles/DevOps200.3x-CIandCD/CDwithJenkins/env/ContinuousDeploymentPartsUnlimitedMRP.json
+++ b/Labfiles/DevOps200.3x-CIandCD/CDwithJenkins/env/ContinuousDeploymentPartsUnlimitedMRP.json
@@ -45,7 +45,7 @@
     "storageName": "[concat('vhdstorage', uniqueString(resourceGroup().id))]",
     "sshKeyPath": "[concat('/home/',parameters('mrpAdminUsername'),'/.ssh/authorized_keys')]",
     "customScript": {
-        "fileUris": "https://raw.githubusercontent.com/Microsoft/PartsUnlimitedMRP/master/docs/assets/jenkins/env/install_mrp_dependencies.sh",
+        "fileUris": "https://raw.githubusercontent.com/Microsoft/PartsUnlimitedMRP/master/Labfiles/DevOps200.3x-CIandCD/CDwithJenkins/env/install_mrp_dependencies.sh",
         "commandToExecute": "bash install_mrp_dependencies.sh"
     }
   },


### PR DESCRIPTION
All credit to @richieteh94 who identified the following fix for issue #152 for the [Continuous Deployment with Jenkins](https://microsoft.github.io/PartsUnlimitedMRP/cicd/200.3x-CICD-CDwithJenkins.html) lab.

The URI specified on line 48 of the file [ContinuousDeploymentPartsUnlimitedMRP.json](https://github.com/Microsoft/PartsUnlimitedMRP/blob/master/Labfiles/DevOps200.3x-CIandCD/CDwithJenkins/env/ContinuousDeploymentPartsUnlimitedMRP.json) points to a script file, which deploys a VM to Azure. The URL is outdated and needs to be modified so that it matches the current location of the deployment script file. The Jenkins lab is broken without the fix. 