### PR TITLE
Update 2018-01-08-200.3x-CICD-CDwithJenkins.md

### DIFF
--- a/_posts/2018-01-08-200.3x-CICD-CDwithJenkins.md
+++ b/_posts/2018-01-08-200.3x-CICD-CDwithJenkins.md
@@ -189,7 +189,7 @@ http://localhost:8080/job/PartsUnlimitedMRP/configure
             sh "ssh -o StrictHostKeyChecking=no -l mrpadmin  ${mrphostname} 'curl -O ${env.BUILD_URL}/artifact/build/libs/integration-service-0.1.0.jar'"
             sh "ssh -o StrictHostKeyChecking=no -l mrpadmin  ${mrphostname} 'curl -O ${env.BUILD_URL}/artifact/build/libs/ordering-service-0.1.0.jar'"
             sh "ssh -o StrictHostKeyChecking=no -l mrpadmin  ${mrphostname} 'curl -O ${env.BUILD_URL}/artifact/MongoRecords.js'"
-            sh "ssh -o StrictHostKeyChecking=no -l mrpadmin  ${mrphostname} 'curl -sL https://raw.githubusercontent.com/Microsoft/PartsUnlimitedMRP/master/docs/assets/jenkins/env/deploy_mrp_app.sh | sudo bash -'"
+            sh "ssh -o StrictHostKeyChecking=no -l mrpadmin  ${mrphostname} 'curl -sL https://raw.githubusercontent.com/Microsoft/PartsUnlimitedMRP/master/Labfiles/DevOps200.3x-CIandCD/CDwithJenkins/env/deploy_mrp_app.sh | sudo bash -'"
             }
         sh "curl -sL -w \"%{http_code}\\n\" http://${mrphostname}:9080/mrp/ -o /dev/null"
     }
@@ -258,7 +258,7 @@ node{
             sh "ssh -o StrictHostKeyChecking=no -l mrpadmin  ${mrphostname} 'curl -O ${env.BUILD_URL}/artifact/build/libs/integration-service-0.1.0.jar'"
             sh "ssh -o StrictHostKeyChecking=no -l mrpadmin  ${mrphostname} 'curl -O ${env.BUILD_URL}/artifact/build/libs/ordering-service-0.1.0.jar'"
             sh "ssh -o StrictHostKeyChecking=no -l mrpadmin  ${mrphostname} 'curl -O ${env.BUILD_URL}/artifact/MongoRecords.js'"
-            sh "ssh -o StrictHostKeyChecking=no -l mrpadmin  ${mrphostname} 'curl -sL https://raw.githubusercontent.com/Microsoft/PartsUnlimitedMRP/master/docs/assets/jenkins/env/deploy_mrp_app.sh | sudo bash -'"
+            sh "ssh -o StrictHostKeyChecking=no -l mrpadmin  ${mrphostname} 'curl -sL https://raw.githubusercontent.com/Microsoft/PartsUnlimitedMRP/master/Labfiles/DevOps200.3x-CIandCD/CDwithJenkins/env/deploy_mrp_app.sh | sudo bash -'"
             }
         sh "curl -sL -w \"%{http_code}\\n\" http://${mrphostname}:9080/mrp/ -o /dev/null"
     }


### PR DESCRIPTION
@richieteh94 recommended updating the inline pipeline script for Jenkins CICD lab, Task 4, issue #153
The lab steps use an outdated URI on lines 192 and 261 in the lab markdown file 2018-01-08-200.3x-CICD-CDwithJenkins.md. The URI points to a script file used in the Jenkins pipeline for deploying artifacts to the Jenkins MRP app VM. The location of the script file has changed and the URI needs to be modified to match the new script location.