### PR TITLE
Remove ref. to line num. from task4 pipline script

### DIFF
--- a/_posts/2018-01-08-200.3x-CICD-CDwithJenkins.md
+++ b/_posts/2018-01-08-200.3x-CICD-CDwithJenkins.md
@@ -156,7 +156,7 @@ In this task we will update the Jenkins pipeline to automatically deploy the art
 http://localhost:8080/job/PartsUnlimitedMRP/configure
 ```
 
-- In the pipeline tab, go to the end of the script (line 30). Insert the following code _before the final closing brace_ `}`.
+- In the pipeline tab, go to the end of the script. Insert the following code _before the final closing brace_ "`}`".
 
 ```js
     stage ('Save MongoRecords.js') {


### PR DESCRIPTION
Task 4, "Update the Jenkins pipeline", provides instructions to paste copied code after line 30 of the pipeline script.
To avoid confusion, change the instruction to "Insert the following code before the final closing brace", rather than referring to a specific line number. The line spacing in the pipeline script from the prerequisite lab differs from the line spacing in the example pipeline script within this lab. As a result, the line numbers don't correlate.