### PR TITLE
Remove whitespace, typos, edit text

### DIFF
--- a/_posts/2018-01-08-200.2x-IaC-DeployappwithChefonAzure.md
+++ b/_posts/2018-01-08-200.2x-IaC-DeployappwithChefonAzure.md
@@ -3,6 +3,7 @@ layout: page
 title:  Deploy app with Chef on Azure
 category: IaC
 order: 5
+date: 16 Sept 2019
 ---
 
 In this lab, we will deploy the *PartsUnlimted MRP Application* (PU MRP App) via *Chef Server* to Azure. The lab is designed to point out some of the key features and capabilities of using Chef with Azure, and to discuss and describe them. Completing this lab will enable you to understand and explain these features and capabilities to customers, as part of the DevOps Lifecycle.
@@ -43,7 +44,7 @@ This lab is used in the following courses.
 
 ### Chef deployment options in Azure
 
-The following deployment options are available for using a Chef in Azure.
+The following deployment options are available for using Chef in Azure.
 
 - *Install a clean Linux VM*. We can install an Ubuntu image SKU in a VM on Azure, and then install and configure *Chef Server* in that VM.
 - *Install Chef Automate*. This image SKU is available on Azure. The Chef Automate image includes a number of Chef services, such as Chef Server.
@@ -81,7 +82,7 @@ For this lab, your local machine will act as the Chef Workstation. We will use A
 2. Fill out the required fields with the following details. Add your initials or other unique identifier as a suffix to create a unique name, where required.
 
     - **Subscription**. `< your Azure subscription >`.
-    - **Resource group**.  `< a unique resource group name >`. For example `chefrgek017`.
+    - **Resource group**.  Choose **Create new** and enter a `< a unique resource group name >`. For example `chefrgek017`.
     - **Location**: Select a region to deploy the Resource Group to. For example `West Europe` or `East US`.
     - **Admin Username**. `azureuser`.
     - **Admin Password**. `Passw0rd0134`.
@@ -108,13 +109,13 @@ For this lab, your local machine will act as the Chef Workstation. We will use A
 
     ![Screenshot of the resources listed under the chefrgek017 Resource Group in Azure Portal. The resource Name column is highlighted to illustrate how to verify that required Chef resources were created, by checking the resource names in the list. The Deployments 5 Succeeded message is also highlighted to illustrate how to access a list of recently successful deployments, from within the list of resources.](../assets/pumrpdeploywithchef-feb2019/chefresourceslist.png)
 
-4.  Verify that the **Status** for each deployment operation is **Succeeded**.
+4. Verify that the **Status** for each deployment operation is **Succeeded**.
 
     ![Screenshot of the deployment operation listed under the Deployment pane, in Azure Portal. The deployment Status column is highlighted beside the names of the Chef-related deployment operations. The status for each deployment operation is shown as Succeeded. The highlighting illustrates how to check the status of deployment operations within the chefrgek017 Resource Group](../assets/pumrpdeploywithchef-feb2019/chefdeploymentsucceeded.png)
 
 5. You need to obtain the public DNS name for your Chef Automate instance. Select the **Resource Groups blade** in Azure Portal. Choose the Resource Group you created previously (for example, **chefrgek017**). Select the **chefautomateip** resource (or whatever you called it) from the resources list.
 
-	 ![Screenshot of the chefautomateip resource, listed under the chefrgek017 Resource Group, in Azure Portal. The Resource Groups blade on the Azure menu is highlighted to illustrate how to access a list of Resource Groups from the Azure menu. The chefrgek017 Resource Group is highlighted inside the Resource Groups blade to illustrate how to access a list of resources within a particular Resource Group. The chefautomateip resource is highlighted inside the chefrgek017 Resource Group to illustrate how to access a particular resource from within a Resource Group list.](../assets/pumrpdeploywithchef-feb2019/chefautomateip.png)
+    ![Screenshot of the chefautomateip resource, listed under the chefrgek017 Resource Group, in Azure Portal. The Resource Groups blade on the Azure menu is highlighted to illustrate how to access a list of Resource Groups from the Azure menu. The chefrgek017 Resource Group is highlighted inside the Resource Groups blade to illustrate how to access a list of resources within a particular Resource Group. The chefautomateip resource is highlighted inside the chefrgek017 Resource Group to illustrate how to access a particular resource from within a Resource Group list.](../assets/pumrpdeploywithchef-feb2019/chefautomateip.png)
 
    Copy the **DNS name** value from the **Public IP address pane**. The **DNS name** value will be a URL, in the following format `machinename`.`region`.`cloudapp.azure.com`
 
@@ -126,7 +127,7 @@ For this lab, your local machine will act as the Chef Workstation. We will use A
 
     The following screenshot is from inside the Microsoft *Edge* web browser. To go to the page, choose **Details**, then select **Go on to the webpage**.
 
-	![Screenshot of a warning inside the Microsoft Edge web browser which states that the requested webpage is not secure. The screenshot illustrates the warning that will be shown in the Microsoft Edge web browser when accessing the DNS name URL for the Chef Automate VM.](../assets/pumrpdeploywithchef-feb2019/chef_pagewarning1.png)
+    ![Screenshot of a warning inside the Microsoft Edge web browser which states that the requested webpage is not secure. The screenshot illustrates the warning that will be shown in the Microsoft Edge web browser when accessing the DNS name URL for the Chef Automate VM.](../assets/pumrpdeploywithchef-feb2019/chef_pagewarning1.png)
 
 7. If the deployment of the Chef Automate image has succeeded, you should see the **Chef Automate login** prompt.
 
@@ -140,13 +141,15 @@ In this task, you will configure your Chef Workstation by setting up the Chef St
 
 1. Download and install the **Chef Development Kit** (Chef DK) from <a href="https://downloads.chef.io/chefdk" target="_blank"><span style="color: #0066cc;">https://downloads.chef.io/chefdk</span></a>. Choose the version of the Chef Development Kit appropriate to your particular environment, i.e. Mac OSX/macOS, Debian, Red Hat Enterprise Linux, SUSE Linux Enterprise Server, Ubuntu, Windows, etc.
 
-	> **Note**: As of February 2019 the latest version of the Chef Development Kit is 3.6.57. Chef Development Kit 3.6.57-1-x64 for Windows 10 is the version used in this lab.
+    > **Note**: As of September 2019 the latest version of the Chef Development Kit is 4.3.13. Chef Development Kit `chefdk-4.3.13-1-x64` for Windows 10 is the version used in this lab.
 
 2. Once installed, you should have a shortcut for **Chef Development Kit** on your desktop. Use the shortcut to launch the Chef Development Kit, and run the following command in the **Chef Development Kit PowerShell window**.
 
     ```powershell
     chef verify
     ```
+
+    If prompted, type **yes** to accept the Chef License terms.
     Keep the PowerShell window open, you will use it again later in this lab.
 
     **Running `Chef Verify`**
@@ -162,16 +165,16 @@ In this task, you will configure your Chef Workstation by setting up the Chef St
 
       ![Screenshot of a PowerShell window showing a completed Chef verify command. An error message indicates that the verification process has failed for the user's Git identity information. The error message is highlighted to illustrate how to identify the error within the PowerShell window.](../assets/pumrpdeploywithchef-feb2019/chef_giterror.png)
 
-3. In the **Chef DK PowerShell** window, configure your global Git variables with your name and email address if you haven't already. We will use Git to store our Chef configuration details.
+3. In the **Chef DK PowerShell** window, configure your global Git variables with your name and email address if you have not already done so. We will use Git to store our Chef configuration details.
 
-	Enter the following commands and values into the **Chef DK PowerShell window**.
+    Enter the following commands and values into the **Chef DK PowerShell window**.
 
-	```powershell
-	git config --global user.name “azureuser”
-	git config --global user.email “azureuser@partsunlimitedmrp.local”
-	```
+    ```powershell
+    git config --global user.name “azureuser”
+    git config --global user.email “azureuser@partsunlimitedmrp.local”
+    ```
 
-	Run `chef verify` again to ensure no further Git-related errors exist.
+    Run `chef verify` again to ensure no further Git-related errors exist.
 
 4. You need the *Chef Starter Kit* for accessing your Chef Automate VM instance on Azure. To get the Chef Starter Kit, append `/biscotti/setup` to the public DNS name value for the Chef Automate VM that you installed in Task 1.
 
@@ -187,7 +190,7 @@ In this task, you will configure your Chef Workstation by setting up the Chef St
 
     In your web browser window, on the **Chef Automate Setup Authorization** page you will be prompted to enter a *Virtual Machine ID* (VMID). This is the VMID for the Chef Automate VM that we deployed in Task 1.
 
-5. The VMID is a unique value that is assigned to each VM in Azure. You can obtain the VMID in a number of ways, such as using PowerShell, or with Azure CLI. We will obtain the VMID by connecting to the Chef Automate VM via SSH using PuTTy.
+5. The VMID is a unique value that is assigned to each VM in Azure. You can obtain the VMID in a number of ways, such as using PowerShell, or with Azure CLI. This lab uses the Windows OS, so we will obtain the VMID by connecting to the Chef Automate VM via SSH using PuTTy.
 
     In a Linux environment, you can obtain the VMID in a similar way by connecting to the Chef Automate VM via SSH.
 
@@ -197,9 +200,9 @@ In this task, you will configure your Chef Workstation by setting up the Chef St
     - In PuTTy, open a new SSH connection to your Chef Automate VM. Enter the public DNS name for your Chef Automate VM as the destination **Host Name (or IP address)**. Select **Open** to connect to your Chef Automate VM.
 
       ![Screenshot of the PuTTy application user interface. An example public DNS name for an Chef Automate VM instance on Azure is shown, inside the Host Name (or IP address) field. The Host Name (or IP address) field is highlighted to illustrate where to enter the public DNS name as a Host Name in PuTTy. The Open button is also highlighted to indicate that selecting the button is necessary when opening a new SSH connection in PuTTy.](../assets/pumrpdeploywithchef-feb2019/Chef_automateputtyconnect2.png)
-	  
+
 	  > **Note**: If prompted, choose **Yes** to add the new SSH key to your local registry cache.
-	  
+
 		![Screenshot of a Security Alert massage in PuTTy. The message indicates that PuTTy is requesting to add the Chef Automate VM server's host key in the local machine's registry, and is requesting user action. The Yes button response is highlighted to illustrate how to affirm the request in PuTTy. ](../assets/pumrpdeploywithchef-feb2019/putty-addkey.png)
 
     - A new bash terminal window will open. When prompted, inside the bash terminal, login into the Chef Automate VM using the username and password credentials you specified in Task 1, i.e.
@@ -214,7 +217,7 @@ In this task, you will configure your Chef Workstation by setting up the Chef St
 
         ![Screenshot of a bash terminal. The command for retrieving the VMID of the Chef Automate VM instance, and the results or running the command, are highlighted. The highlighted display elements illustrate how to run the command and view its results in a bash terminal.](../assets/pumrpdeploywithchef-feb2019/getvmid1.1.png)
 
-		Exit the PuTTy terminal with the following command.
+        Exit the PuTTy terminal with the following command.
 
       ```bash
       exit
@@ -248,7 +251,7 @@ In this task, you will configure your Chef Workstation by setting up the Chef St
 
 	![Screenshot of the Download Chef Starter Kit web page. The download Chef Starter Kit is highlighted to indicate that selecting the button is required to download Chef Starter Kit.](../assets/pumrpdeploywithchef-feb2019/chef-startkitdownload.png)
 
-9. After you have downloaded the **Chef Starter Kit**, the **Login to Chef Automate** button will be enabled. Select the button, and sign into Chef Automat by entering the username and password you provided on the **Chef Automate Setup** web page. The **Chef Automate dashboard** should now be visible in your web browser.
+9. After you have downloaded the **Chef Starter Kit**, the **Login to Chef Automate** button will be enabled. Select the button, and sign into Chef Automate by entering the username and password you provided on the **Chef Automate Setup** web page. The **Chef Automate dashboard** should now be visible in your web browser.
 
 	![Screenshot of the Chef Automate dashboard inside a web browser, to illustrate the appearance of the dashboard.](../assets/pumrpdeploywithchef-feb2019/Chef_chefautomatedashboard1.png)
 
@@ -256,7 +259,7 @@ In this task, you will configure your Chef Workstation by setting up the Chef St
 
 11. Go to the location where you extracted the Chef Starter Kit files. **Open** the file `~\chef-repo\.chef\knife.rb` in an editor. Check that the value assigned to `chef_server_url`, for the external FQDN (Fully Qualified Domain Name), corresponds to the following.
 
-	`https:`//`<chef-server-dns-name>`.`<region>`.`cloudapp.azure.com/organizations/default` 
+	`https:`//`<chef-server-dns-name>`.`<region>`.`cloudapp.azure.com/organizations/default`
 
 	Then, **save** and **close** the file.
 
@@ -332,7 +335,7 @@ In this exercise, you will create a cookbook and recipe for the PU MRP app's dep
 	![Screenshot of a PowerShell window. The chef generate cookbook command has been run, and a new cookbook has been created successfully. The command and its output are shown to illustrate how to run the commands in PowerShell.](../assets/pumrpdeploywithchef-feb2019/chef_cookbooks1.1.png)
 
 	A cookbook is a set of tasks for configuring an application or feature. It defines a scenario and everything required to support that scenario. Within a cookbook, there are a series of *recipes* that define a set of actions for the cookbook to perform. Cookbooks and recipes are written in the *Ruby* language. 
-	
+
 	The `chef generate cookbook` command we ran here creates an `mrpapp` directory in the `~/chef-repo/cookbooks/` directory. The `mrpapp` directory contains all of the boilerplate code that defines a cookbook and a default recipe.
 
 	![Screenshot of the contents of the mrpapp directory, inside the chef-repo/cookbooks/ directory, in Windows Explorer. The contents of the directory are shown to illustrate the directory and file structure within a default Chef cookbook directory.](../assets/pumrpdeploywithchef-feb2019/view_mrp_cookbook1.png)
@@ -349,7 +352,7 @@ In this exercise, you will create a cookbook and recipe for the PU MRP app's dep
 
 3. We need to install three dependencies for our recipe: the `apt` cookbook, the `windows` cookbook, and the `chef-client` cookbook. We can download the three cookbooks from the official Chef cookbook repository, [https://supermarket.chef.io/cookbooks](https://supermarket.chef.io/cookbooks), using the `knife cookbook site` command.
 
-	In the **Chef Development Kit** (Chef DK) PowerShell window, from inside the directory `\chef\chef-repo\cookbooks`, download the cookbooks using the `knife cookbook site` command as follows.
+	In the **Chef Development Kit** (Chef DK) PowerShell window, from inside the directory `~\chef\chef-repo\cookbooks`, download the cookbooks using the `knife cookbook site` command as follows.
 
 	Install the apt cookbook:
 
@@ -397,7 +400,7 @@ In this exercise, you will create a cookbook and recipe for the PU MRP app's dep
 
 8. The following explains how the recipe we copied will provision our application, by going through `default.rb` line-by-line.
 
-	The recipe will run the `apt` resource – this will cause our recipe to execute `apt-get update` command prior to running. This command makea sure the package sources on the machine are up-to-date.
+	The recipe will run the `apt` resource – this will cause our recipe to execute `apt-get update` command prior to running. This command makes sure the package sources on the machine are up-to-date.
 
 	```ruby
 		↪	# Runs apt-get update
@@ -450,9 +453,9 @@ In this exercise, you will create a cookbook and recipe for the PU MRP app's dep
 		↪	end
 	```
 
-	At this point, all of our dependencies will be installed. We can then can start configuring our applications. First, we need to ensure that our MongoDB database has some baseline data in it. The `remote_file` resource will download a file to a specified location. 
+	At this point, all of our dependencies will be installed. We can then can start configuring our applications. First, we need to ensure that our MongoDB database has some baseline data in it. The `remote_file` resource will download a file to a specified location.
 	
-	It is *idempotent* which means, in this context, if the file on the server has the same checksum as the local file, no action will be taken. 
+	It is *idempotent* which means, in this context, if the file on the server has the same checksum as the local file, no action will be taken.
 	
 	We also use the `notifies` command. For example, if a new version of the file is present when the resource runs, a notification is sent to the specified resource, telling it to run the new file.
 
@@ -466,7 +469,7 @@ In this exercise, you will create a cookbook and recipe for the PU MRP app's dep
 		↪	end
 	```
 
-	Next we use a `script` resource to set the command line script that runs to load the MongoDB data we downloaded in the previous step. 
+	Next we use a `script` resource to set the command line script that runs to load the MongoDB data we downloaded in the previous step.
 	
 	The `script` resource has its `action` parameter set to `nothing`, which means the script will only run when it receives a notification to run. The only time this resource will run is when it is notified by the `remote_file resource` we specified in the previous step. So every time a new version of the `MongoRecord.js` file is uploaded, the recipe will download and import it. If the `MongoRecords.js` file does not change, nothing is downloaded or imported!
 
@@ -527,7 +530,7 @@ In this exercise, you will create a cookbook and recipe for the PU MRP app's dep
     	↪	# Kill the ordering service
     	↪	script 'stop_ordering_service' do
     	↪		interpreter "bash"
-    	↪	# Only run when notifed
+    	↪	# Only run when notified
     	↪		action :nothing
     	↪		code "pkill -f ordering-service"
     	↪		only_if "pgrep -f ordering-service"
@@ -561,7 +564,7 @@ In this exercise, you will create a cookbook and recipe for the PU MRP app's dep
 
 ### Task 4: Create a Role
 
-In this exercise, you will use the `knife` command to create a *Role*. The role will define a baseline set of cookbooks and attributes that can be applied to multiple servers. 
+In this exercise, you will use the `knife` command to create a *Role*. The role will define a baseline set of cookbooks and attributes that can be applied to multiple servers.
 
 > **Note**: For more information see the Chef Documentation page <a href="https://docs.chef.io/knife_role.html" target="_blank"><span style="color: #0066cc;">Knife Role</span></a>.
 
@@ -575,9 +578,9 @@ In this exercise, you will use the `knife` command to create a *Role*. The role 
 
 	![Screenshot of the local knife.rb, open inside the Visual Studio Code editor, with the added line knife[:editor] = "notepad" highlighted. The image illustrates how to edit the local knife.rb and how the file appears after editing.](../assets/pumrpdeploywithchef-feb2019/chef_notepadedit2-1.png)
 
-	Adding this line specifies *Notepad* as the editor to open the `knife.rb` when we create a role, in the next step. If you do not specify an editor in the `knife.rb`, when you run the command in step 3 you will receive an error. The error message will state something such as *"Runtime ERROR: please set editor environment variable..."*
+	Adding this line specifies Windows *Notepad* as the editor to open the `knife.rb` when we create a role, in the next step. If you do not specify an editor in the `knife.rb`, when you run the command in step 3 you will receive an error. The error message will state something such as *"Runtime ERROR: please set editor environment variable..."*
 
-3. In the **Chef DK** window run the following command to create the role, which we will name `partsrole`.
+3. In the **Chef DK** PowerShell window run the following command to create the role, which we will name `partsrole`.
 
 	```powershell
 	knife role create partsrole
@@ -613,7 +616,7 @@ In this exercise, you will use the `knife` command to create a *Role*. The role 
 	],
 	```
 
-	The completed file should be similar to the file in the following screenshot. 
+	The completed file should be similar to the file in the following screenshot.
 
 	![Screenshot of a knife json file open in the Windows Notepad editor. The previously described json key-value pairs have been added to the file. The image illustrates how to edit the json file in Notepad and how the json file will appear after editing. ](../assets/pumrpdeploywithchef-feb2019/knife-editjson.png)
 
@@ -627,7 +630,7 @@ In this exercise, you will use the `knife` command to create a *Role*. The role 
 
 In this exercise, you will use knife to bootstrap the PU MRP Application Server and assign the PU MRP application role.
 
-1. Create a Linux VM in which to run the PU MRP application, by selecting the **Deploy to Azure** button. This will add a VM image template directly into Azure. You will need to sign in to Azure Portal to deploy the image.
+1. The PU MRP application will run on Azure in a Linux VM. Create the Linux VM by selecting the **Deploy to Azure** button. This will add a VM image template directly into Azure. You will need to sign in to Azure Portal to deploy the image.
 
 	<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FMicrosoft%2FPartsUnlimitedMRP%2Fmaster%2FLabfiles%2FAZ-400T05-ImplemntgAppInfra%2FLabfiles%2FM04%2FDeployusingChef%2Fenv%2Fdeploylinux.json" target="_blank"><img src="http://azuredeploy.net/deploybutton.png"/>
 	</a>
@@ -648,15 +651,15 @@ In this exercise, you will use knife to bootstrap the PU MRP Application Server 
 
 3. Once the template has deployed, return to the **Chef DK** PowerShell window. From inside your Chef repo directory, e.g. `C:/Users/<username>/chef/chef-repo`, use knife to bootstrap the PU MRP app VM by running the following command.
 
-	> **Note**: The value you enter for **FQDN-for-MRP-App-VM** is the `Dns Label Prefix` and `location` you assigned to the PU MRP application VM in the previous step, with the suffix `cloudapp.azure.com`. The FQDN-for-MRP-App-VM value is in the format `< Dns Label Prefix >`.`< region >`.`cloudapp.azure.com`. For example, `ppmrppartsek017.westeurope.cloudapp.azure.com`.
-	>
-	> Substitute the username and password you set in the previous step for `<mrp-app-admin-username>` and `<mrp-app-admin-password>`. For example, `azureuser` and `Passw0rd0134`.
+	> **Note**: You need to obtain the Public DNS name for your MRP App VM. To obtain the DNS name, select the **Resource Groups** blade in Azure Portal. Choose the Resource Group that you created in the previous step (for example, `chefmrplinuxvmrg`). Select the `mmrpPublicIP` resource (or whatever you called it) from the resources list. Copy the `DNS name` value. For example, `ppmrppartsek017.westeurope.cloudapp.azure.com`.
+    >
+    > In the following `knife bootstrap` command, enter the DNS name you obtained as the value for `<FQDN-for-MRP-App-VM>`. You should also substitute the username and password that you set in the previous step for `<mrp-app-admin-username>` and `<mrp-app-admin-password>`. For example, `azureuser` and `Passw0rd0134`.
 
 	```powershell
-	knife bootstrap <FQDN-for-MRP-App-VM> --ssh-user <mrp-app-admin-username>
-	--ssh-password <mrp-app-admin-password> --node-name mrp-app --run-list role[partsrole] 
-	--sudo --verbose
+	knife bootstrap <FQDN-for-MRP-App-VM> --ssh-user <mrp-app-admin-username> --ssh-password <mrp-app-admin-password> --node-name mrp-app --run-list role[partsrole] --sudo --verbose
 	```
+
+    If prompted to continue connecting, type **"Y"** and press **Return**.
 
 	![Screenshot of a PowerShell window. The knife bootstrap command is running. The knife command is shown with the sample FQDN-for-MRP-App-VM, username and password values to illustrate how to run the bootstrap command in PowerShell.](../assets/pumrpdeploywithchef-feb2019/knife-bootstrap.png)
 
@@ -673,24 +676,25 @@ In this exercise, you will use knife to bootstrap the PU MRP Application Server 
 	- The installation may not do anything for the first minute, while it connects and prepares to run. However, if it hangs for more than 5 to 10 minutes, cancel the run and note any error messages that are returned.
 	- If error messages relate to disconnecting from the remote host, it may be a username or password issue. You should recheck the user account details on the Chef Automate server, and on the Linux VM. Use PuTTy to sign in to the VMs.
 	- You can also set up the connection to use certificates instead of a username and password.
-	- If there is an error related to resolving the run list, you will need to run the following command in Chef DK and try again. This command will make sure the missing role is in the node.
+	- If there is an error related to resolving the run list, you will need to run the following command in the Chef DK PowerShell window and try again. This command will make sure the missing role is in the node.
 
 		```ruby
 		knife node run_list add mrp-app 'role[partsrole]'
 		```
 
-4. Open the URL you chose for your public DNS name in a web browser, with the suffix `:9080/mrp/`. The URL should be in the following format `http:`//`<mrp-dns-name>`.`<region>`.`cloudapp.azure.com:9080/mrp/`. If the installation was successful, you should see the PU MRP application landing web page.
+4. Open a web browser and, in the address bar, enter the Public DNS name of your MRP App VM with the suffix `:9080/mrp/`. The URL should be in the following format `http:`//`<mrp-dns-name>`.`<region>`.`cloudapp.azure.com`:`9080/mrp/`. For example, `http://ppmrppartsek017.westeurope.cloudapp.azure.com:9080/mrp/`. If the installation was successful, you should see the PU MRP application landing web page.
 
 	![Screenshot of the PU MRP application landing page inside a web browser. The PU MRP application landing web page is shown to illustrate how view the web page in a web browser.](../assets/pumrpdeploywithchef-feb2019/mrp_webpage1.png)
 
 5. Explore the web site and check that it functions normally.
 
-6. Visit the URL for your Chef Automate server in your web browser, for example `https://chefautomateek017.westeurope.cloudapp.azure.com`. Log in to your Chef Automate server. From the **Chef Automate Dashboard**, go to the **Nodes** area. Verify the PU MRP Application VM is listed as node `mrp-app`.
+6. Visit the URL for your **Chef Automate server** in your web browser, for example `https://chefautomateek017.westeurope.cloudapp.azure.com`. Log in to your Chef Automate server. From the **Chef Automate Dashboard**, go to the **Nodes** area. Verify the PU MRP Application VM is listed as node `mrp-app`. Select the `mrp-app` from the bottom of the dashboard.
 
-	Examine the details listed under the **Resources**, **Run List** and **Attributes** tabs, and verify that the details are as expected.
+	![Screenshot of the Chef Automate Dashboard inside a web browser. The Node tab and mrp-app node are highlighted to illustrate how to access these areas from the Chef dashboard, in order to verify their details.](../assets/pumrpdeploywithchef-feb2019/chef_chefautodashboard_nodestab.png)
 
-	![Screenshot of the Chef Automate Dashboard inside a web browser. The mrp-app node, and the tabs Nodes, Resources, Run List and Attributes are highlighted to illustrate how to access these areas from the dashboard, in order to verify their settings and details.](../assets/pumrpdeploywithchef-feb2019/chef_chefautodashboard.png)
+	From the **Run History** panel, choose **Last 24 hours** from the dropdown list and select the **Apply** button. Examine the details listed under the **Resources**, **Run List** and **Attributes** tabs, and verify that the details are as expected.
 
+	![Screenshot of the Chef Automate Dashboard inside a web browser. The Run History, Resources, Run List and Attributes elements are highlighted to illustrate how to access these areas from the dashboard, in order to verify their settings and details.](../assets/pumrpdeploywithchef-feb2019/chef_chefautodashboard-01.png)
 
 	> **Note**: You can manage your Chef server configuration and node deployments via a web browser by installing the *Chef Management Console*. Go to your Chef Automate server deployment organization page by appending `/organizations/default` to the URL you use to access your Chef Automate server. The resulting URL should be similar to `https:`//`< your chef automate server dns name >`.`< region >`.`cloudapp.azure.com`/`organizations/default`. Visit the URL, and follow the instructions on the web page to install the Chef Management Console.
 


### PR DESCRIPTION
- Line # 6 Add new date field to the .md file header to manage
.md file revisions/ version control.
- Line # 47 Typo: a Chef vs Chef.
- Line # 85 Add step to create new resource group.
- Line # 144 Update Chef Development Kit version.
- Line # 152 Add reference to accept the Chef License terms.
- Line # 169 Remove contraction (haven't) which may confuse some readers.
- Line # 193 Clarification needed as next sentence refers to Linux OS.
- Line # 254 Typo: automat vs automate.
- Line # 355 Add ~ before file path for clarification.
- Line # 401 Typo: makea vs makes.
- Line # 533 Typo: notifed vs notified.
- Line # 581 Add clarity by specifying Windows Notepad.
- Line # 583 Add clarity by specifying Chef DK PowerShell window.
- Line # 633 Add sentence re: Linux VM purpose, for clarity.
- Line # 659 Remove carriage returns/ line from knife bootstrap command that
cause the command to fail if copied and pasted.
- Line # 662 Add reference to on-screen prompt for connecting to MRP-App VM via
SSH.
- Line # 664 Edit note text re: FQDN-for-MRP-App-VM for clarity.
- Line # 679 Specify Chef DK is a PowerShell window for clarity.
- Line # 685 Edit Step 4 by specifying the use of the MRP App VM Public DNS for
clarity.
- Lines # 691 to 697 Add new text and screenshot filename:
chef_chefautodashboard_nodestab.png to illustrate how to access the "nodes" tab
from chef automate dashboard. Add new text and screenshot filename:
chef_chefautodashboard-01.png to illustrate how to access "Run History",
"Resources", "Run List" and "Attributes" from chef automate dashboard.