### PR TITLE
Use https for repo requests.

### DIFF
--- a/src/Backend/IntegrationService/build.gradle
+++ b/src/Backend/IntegrationService/build.gradle
@@ -1,5 +1,8 @@
 buildscript {
     repositories {
+        maven { url "https://repo.spring.io/libs-release" }
+        maven { url "https://gradle.artifactoryonline.com/gradle/libs/" }
+        mavenLocal()
         mavenCentral()
     }
     dependencies {

--- a/src/Backend/OrderService/build.gradle
+++ b/src/Backend/OrderService/build.gradle
@@ -2,8 +2,8 @@ import com.microsoft.appinsights.*
 
 buildscript {
     repositories {
-        maven { url "http://repo.spring.io/libs-release" }
-        maven { url "http://gradle.artifactoryonline.com/gradle/libs/" }
+        maven { url "https://repo.spring.io/libs-release" }
+        maven { url "https://gradle.artifactoryonline.com/gradle/libs/" }
         mavenLocal()
         mavenCentral()
     }

--- a/src/Backend/OrderService/gradle/wrapper/gradle-wrapper.properties
+++ b/src/Backend/OrderService/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.1-bin.zip

--- a/src/Clients/gradle/wrapper/gradle-wrapper.properties
+++ b/src/Clients/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.1-bin.zip


### PR DESCRIPTION
use https, because http is blocked which causes the builds to fail in the lab.